### PR TITLE
Handle M-series FIN numbers, improve tests

### DIFF
--- a/src/Repat/LaravelRules/NricFin.php
+++ b/src/Repat/LaravelRules/NricFin.php
@@ -7,16 +7,6 @@ use Illuminate\Contracts\Validation\Rule;
 class NricFin implements Rule
 {
     /**
-     * Create a new rule instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
      * Determine if the validation rule passes.
      *
      * @param  string  $attribute
@@ -46,20 +36,37 @@ class NricFin implements Rule
         for ($i = 1; $i < 8; $i++) {
             $weight += $icArray[$i];
         }
-        $offset = ($icArray[0] === 'T' || $icArray[0] == 'G') ? 4 : 0;
+
+        $offset = $this->getOffset($icArray[0]);
         $temp = ($offset + $weight) % 11;
 
         $st = ['J', 'Z', 'I', 'H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'];
         $fg = ['X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'M', 'L', 'K'];
+        $fgM = ['X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'J', 'L', 'K'];
 
         $theAlpha = '';
-        if ($icArray[0] == 'S' || $icArray[0] == 'T') {
+        if ($icArray[0] === 'S' || $icArray[0] === 'T') {
             $theAlpha = $st[$temp];
-        } elseif ($icArray[0] == 'F' || $icArray[0] == 'G') {
+        } elseif ($icArray[0] === 'F' || $icArray[0] === 'G') {
             $theAlpha = $fg[$temp];
+        } elseif ($icArray[0] === 'M') {
+            $theAlpha = $fgM[$temp];
         }
 
         return ($icArray[8] === $theAlpha);
+    }
+
+    private function getOffset(string $prefix): int
+    {
+        if ($prefix === 'T' || $prefix === 'G') {
+            return 4;
+        }
+
+        if ($prefix === 'M') {
+            return 3;
+        }
+
+        return 0;
     }
 
     /**

--- a/tests/NricFinTest.php
+++ b/tests/NricFinTest.php
@@ -3,45 +3,47 @@
 namespace Repat\LaravelRules;
 
 use Illuminate\Support\Str;
+use Orchestra\Testbench\TestCase;
 
-class TestNricFin extends \Orchestra\Testbench\TestCase
+class TestNricFin extends TestCase
 {
-    public function testValidNric()
+    /**
+     * @dataProvider validProvider
+     */
+    public function testValidNric(string $nric): void
     {
-        // First NRIC ever - first president of Singapore
-        $yusofBinIshak = 'S0000001I';
-
-        $nricFin = new NricFin();
-        $this->assertTrue($nricFin->passes('', $yusofBinIshak), $yusofBinIshak);
+        $this->assertTrue((new NricFin())->passes('', $nric));
     }
 
-    public function testTooShortString()
+    /**
+     * @dataProvider invalidProvider
+     */
+    public function testInvalidNric(?string $nric): void
     {
-        $nricFin = new NricFin();
-        $this->assertFalse($nricFin->passes('', Str::random(8)));
+        $this->assertFalse((new NricFin())->passes('', $nric));
     }
 
-    public function testTooLongString()
+    public static function invalidProvider(): iterable
     {
-        $nricFin = new NricFin();
-        $this->assertFalse($nricFin->passes('', Str::random(10)));
+        yield 'Too short string' => [Str::random(8)];
+        yield 'Too long string' => [Str::random(10)];
+        yield 'Empty string' => [''];
+        yield 'Null' => [null];
+        yield 'Correct length but random' => [Str::random(9)];
+        yield 'Invalid checksum 1' => ['T5717279A'];
+        yield 'Invalid checksum 2' => ['F6470401K'];
+        yield 'Invalid checksum 3' => ['G8877699L'];
+        yield 'Invalid checksum 4' => ['M8877689K'];
     }
 
-    public function testEmptyString()
+    public static function validProvider(): iterable
     {
-        $nricFin = new NricFin();
-        $this->assertFalse($nricFin->passes('', ''));
-    }
-
-    public function testNull()
-    {
-        $nricFin = new NricFin();
-        $this->assertFalse($nricFin->passes('', null));
-    }
-
-    public function testCorrectLengthButRandom()
-    {
-        $nricFin = new NricFin();
-        $this->assertFalse($nricFin->passes('', Str::random(9)));
+        yield 'First president of Singapore' => ['S0000001I'];
+        yield 'S6083480F' => ['S6083480F'];
+        yield 'T5717279C' => ['T5717279C'];
+        yield 'F6470401W' => ['F6470401W'];
+        yield 'G8877699U' => ['G8877699U'];
+        yield 'M5043078W' => ['M5043078W'];
+        yield 'M2424771J' => ['M2424771J'];
     }
 }


### PR DESCRIPTION
This PR adds support for M-series FIN numbers: https://www.ica.gov.sg/news-and-publications/newsroom/media-release/new-m-fin-series-to-be-introduced-from-1-january-2022

The checksum calculation is taken from my project which serves a similar purpose: https://github.com/IonBazan/NRIC

I also polished the tests to verify that checksums are being correctly checked.

Let me know if you would like to add `ion-bazan/nric` as a dependency instead (it doesn't add any major dependencies and is compatible with same PHP versions as this library).